### PR TITLE
Set jukebox link to https://www.jukeboxprint.com instead of incorrect http://jukebox.com

### DIFF
--- a/src/routes/guide/branding/+page.svx
+++ b/src/routes/guide/branding/+page.svx
@@ -60,6 +60,6 @@ More fancy ones:
 * Hoodies   
 * Something custom\! 
 
-Note: HCB currently offers a $500 grant for jukebox ([jukebox.com](http://jukebox.com)) if your account has 10+ organizers/people who follows it. 
+Note: HCB currently offers a $500 grant for jukebox ([https://www.jukeboxprint.com/](http://https://www.jukeboxprint.com/)) if your account has 10+ organizers/people who follows it. 
 
 Jukebox is a custom sticker/postcard/prints shop\! 

--- a/src/routes/guide/branding/+page.svx
+++ b/src/routes/guide/branding/+page.svx
@@ -60,6 +60,6 @@ More fancy ones:
 * Hoodies   
 * Something custom\! 
 
-Note: HCB currently offers a $500 grant for jukebox ([https://www.jukeboxprint.com/](http://https://www.jukeboxprint.com/)) if your account has 10+ organizers/people who follows it. 
+Note: HCB currently offers a $500 grant for jukebox ([ukeboxprint.com](http://https://www.jukeboxprint.com/)) if your account has 10+ organizers/people who follows it. 
 
 Jukebox is a custom sticker/postcard/prints shop\! 


### PR DESCRIPTION
The current link sends you to [jukebox.com](http://jukebox.com/), which is just a domain parking.

<img width="3435" height="1326" alt="image" src="https://github.com/user-attachments/assets/6ba4d464-c099-4756-afa9-0541fa8606e1" />