### PR TITLE
Add redirect /vancouver -> daydream.bcydc.ca

### DIFF
--- a/src/routes/vancouver/+page.server.js
+++ b/src/routes/vancouver/+page.server.js
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	throw redirect(308, 'https://daydream.bcydc.ca');
+}

--- a/src/routes/vancouver/+pages.server.js
+++ b/src/routes/vancouver/+pages.server.js
@@ -1,5 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export function load() {
-	throw redirect(308, 'https://daydream.bcydc.ca');
-}

--- a/src/routes/vancouver/+pages.server.js
+++ b/src/routes/vancouver/+pages.server.js
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	throw redirect(308, 'https://daydream.bcydc.ca');
+}


### PR DESCRIPTION
Self hosting at [https://daydream.bcydc.ca](https://daydream.bcydc.ca) via cloudflare pages; keeping the plausible.io link.

Redirecting via /vancouver/+page.server.js

Also majorly refactored the +page.svelte on our repo if you are interested 😼

Lmk if there are concerns.