### PR TITLE
updated schedule for Daydream Manchester

### DIFF
--- a/src/routes/manchester/+page.svelte
+++ b/src/routes/manchester/+page.svelte
@@ -25,17 +25,15 @@
 		{
 			title: "Sunday, September 28th",
 			items: [
-				{ event: "Doors open", time: "8:45" },
-				{ event: "Opening ceremony", time: "9:10" },
-				{ event: "Get into teams, start working on your project!", time: "10:00" },
-				{ event: "Lunch", time: "13:00" },
-				{ event: "Continue working on projects", time: "14:00" },
-				{ event: "Workshop", time: "15:00" },
-				{ event: "More projects work :)", time: "16:00" },
-				{ event: "Dinner", time: "18:00" },
-				{ event: "Ship projects and vote", time: "19:00" },
-				{ event: "Closing Ceremony", time: "20:20" },
-				{ event: "Home!", time: "20:45" }
+				{ event: "Doors open", time: "9:00am" },
+				{ event: "Opening ceremony", time: "9:30am" },
+				{ event: "Get into teams, start working on your project!", time: "10:00am" },
+				{ event: "Godot Workshop for beginners", time: "10:15am" },
+				{ event: "Lunch", time: "1:00pm" },
+				{ event: "Continue working on projects", time: "2:00pm" },
+				{ event: "Ship projects and vote", time: "6:00pm" },
+				{ event: "Closing Ceremony", time: "6:30pm" },
+				{ event: "Home!", time: "7:00pm" }
 				
 			]
 		},
@@ -79,6 +77,7 @@ Ottawa
 Hangzhou
 Islamabad
 London
+Manchester
 Visakhapatnam
 Dubai
 San Francisco


### PR DESCRIPTION
Updated schedule for Daydream Manchester to allow people to have time to catch trains home from Manchester Piccadilly and Victoria Stations.