### PR TITLE
Edit Cambridge Page

### DIFF
--- a/src/routes/cambridge/+page.svelte
+++ b/src/routes/cambridge/+page.svelte
@@ -20,7 +20,6 @@
 	const sponsors = [
 		{ image: "/cambridge/rpilogo.png", name: "The Raspberry Pi Foundation", url: "https://www.raspberrypi.org/" },
 		{ image: "https://assets.hackclub.com/icon-rounded.png", name: "Hack Club", url: "https://hackclub.com/" },
-		{ image: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Arm_logo_2017.svg/1200px-Arm_logo_2017.svg.png", name: "ARM", url: "https://www.arm.com/" },
 		{ image: "https://images.squarespace-cdn.com/content/v1/58f9da0e9f7456dd4588cfe3/1596709094677-SE8RU9SV26CFM7OZPDBH/aromi-cucina-white.png?format=1500w", name: "Aromi", url: "https://www.aromi.co.uk/" }
 	];
 	


### PR DESCRIPTION
Remove ARM from the sponsors list because they want to talk a bit with the team before confirming if we can use their name as our sponsor